### PR TITLE
questions: fix order of parameters for Ch 9 Question 2

### DIFF
--- a/questions/ch9_qs_assignments.txt
+++ b/questions/ch9_qs_assignments.txt
@@ -19,7 +19,7 @@ instance to __________ via a _______.
 void *foo(void)
 {
 	void *v;
-	struct mys *p = kmalloc(GFP_KERNEL, sizeof(struct mys));
+	struct mys *p = kmalloc(sizeof(struct mys), GFP_KERNEL);
 	if (!p)
 		return -ENOMEM;
 


### PR DESCRIPTION
It should be kmalloc(size_t size, gfp_t flags).

Signed-off-by: Vincent Fu <vincentfu@gmail.com>

~~Incidentally, I am confused about the answer to this question saying that the pointer return value from kmalloc cannot be the return value from foo() because it is out of scope. Do you have any references for this? If the return value of foo() is out of scope then why wouldn't the return values of kmalloc() or vmalloc() also be out of scope?~~

Edit: I think that the return of foo() will be out of scope if a user space application attempts to access the memory pointed to by p. So if foo() is called from within a kernel module it's fine to access the memory pointed to by p, but if address that is the return value of foo() is accessed from user space then there will be an exception.