### PR TITLE
corrected memory cleanup path

### DIFF
--- a/solutions_to_assgn/ch8/slab_ptr_array/slab_ptr_array.c
+++ b/solutions_to_assgn/ch8/slab_ptr_array/slab_ptr_array.c
@@ -67,7 +67,7 @@ static int __init slab_ptr_array_init(void)
 
 	return 0;		/* success */
 cleanup:
-	for (j = i; j > 0; j--) {
+	for (j = i-1; j >= 0; j--) {
 		pr_debug(" freeing gkptr[%d]\n", j);
 		kfree(gkptr[j]);
 	}


### PR DESCRIPTION
Variable i holds the time of iteration that kmalloc failed, so you should start cleaning up from i-1 to 0(inclusive).